### PR TITLE
optee_os: add alignment to struct internal_aes_gcm_state

### DIFF
--- a/core/include/crypto/internal_aes-gcm.h
+++ b/core/include/crypto/internal_aes-gcm.h
@@ -45,7 +45,7 @@ struct internal_aes_gcm_state {
 	unsigned int aad_bytes;
 	unsigned int payload_bytes;
 	unsigned int buf_pos;
-};
+} __attribute__((aligned(sizeof(uint64_t))));
 
 struct internal_aes_gcm_ctx {
 	struct internal_aes_gcm_state state;


### PR DESCRIPTION
In OPTEE_OS, there will be an alignment check on the address of the `struct internal_aes_gcm_state`, requiring it to be aligned according to `uint64_t`.
When we compile on the arm32 (qemu) platform, there will be no problem with this alignment. However, when compiling on the x86_64 (sim) platform, we will encounter alignment check issues.
In order to ensure normal operation on the x86_64 (sim) platform as well, we need to add a forced alignment declaration for the `struct internal_aes_gcm_state`.
In this way, the `struct internal_aes_gcm_state` can work properly on both the arm32 (qemu) and x86_64 (sim) platforms.